### PR TITLE
test: Make sure to wait stopping server thread

### DIFF
--- a/test/plugin/test_in_unix_client.rb
+++ b/test/plugin/test_in_unix_client.rb
@@ -9,12 +9,11 @@ require_relative "./unix_server.rb"
 class UnixClientInputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
-    @thread = nil
+    @server_thread = nil
   end
 
   def teardown
-    @thread.kill if @thread
-    @thread = nil
+    stop_server
     FileUtils.rm_rf(TMP_DIR)
   end
 
@@ -125,11 +124,19 @@ class UnixClientInputTest < Test::Unit::TestCase
   end
 
   def start_server(path)
-    @thread = Thread.new do
+    @server_thread = Thread.new do
       server = UnixBroadcastServer.new(path)
       server.run
     end
     sleep 1
+  end
+
+  def stop_server
+    if @server_thread
+      @server_thread.kill if @server_thread
+      @server_thread.join
+      @server_thread = nil
+    end
   end
 
   def send_json(path, time: nil, msg: DEFAULT_MSG, delimiter: "\n")


### PR DESCRIPTION
Otherwise sometimes following error is occured:

```
Traceback (most recent call last):
	5: from /home/aho/Projects/Fluentd/fluent-plugin-unix-client/test/plugin/test_in_unix_client.rb:130:in `block in start_server'
	4: from /home/aho/Projects/Fluentd/fluent-plugin-unix-client/test/plugin/unix_server.rb:21:in `run'
	3: from /usr/lib/ruby/2.7.0/socket.rb:1164:in `unix_server_loop'
	2: from /usr/lib/ruby/2.7.0/socket.rb:1123:in `unix_server_socket'
	1: from /usr/lib/ruby/2.7.0/socket.rb:1123:in `ensure in unix_server_socket'
/usr/lib/ruby/2.7.0/socket.rb:1123:in `unlink': No such file or directory @ apply2files - /home/aho/Projects/Fluentd/fluent-plugin-unix-client/test/plugin/../tmp/socket/socket.sock (Errno::ENOENT)
```
