### PR TITLE
Make it possible to receive JSON list data

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,19 @@ The payload is read up to this character.
 
 Default value: `"\n"` (newline).
 
+### format_json (bool) (optional)
+
+When recieved JSON data splitted by the delimiter is not completed, like '[{...},', trim '[', ']' and ',' characters to format.
+
+Please see `Sample` below for details.
+
+Default value: false.
+
 ## Sample
+
+### For JSON
+
+Config:
 
 ```
 <source>
@@ -64,6 +76,53 @@ Default value: `"\n"` (newline).
 <match debug.**>
   @type stdout
 </match>
+```
+
+Assumed Data:
+
+* ndjson
+```
+{"key":0}\n
+{"key":0}\n
+...
+```
+
+* JSON list
+```
+[{"key":0}, {"key":0}, ...]\n
+[{"key":0}, {"key":0}, ...]\n
+...
+```
+
+### Use `format_json`
+
+Config:
+
+```
+<source>
+  @type unix_client
+  tag debug.unix_client
+  path /tmp/unix.sock
+  <parse>
+    @type json
+  </parse>
+  delimiter "\n"
+  format_json true
+</source>
+
+<match debug.**>
+  @type stdout
+</match>
+```
+
+Assumed Data:
+
+```
+[{"key":0},\n
+{"key":0},\n
+...
+{"key":0}]\n
+...
 ```
 
 ## Specification

--- a/test/plugin/test_in_unix_client.rb
+++ b/test/plugin/test_in_unix_client.rb
@@ -31,6 +31,14 @@ class UnixClientInputTest < Test::Unit::TestCase
     d = create_driver(config_with_json_parser)
     assert_equal "unix_client", d.instance.tag
     assert_equal "#{TMP_DIR}/socket.sock", d.instance.path
+    assert_equal false, d.instance.format_json
+  end
+
+  def test_configure_with_format_json
+    d = create_driver(config_with_json_parser_and_format_json)
+    assert_equal "unix_client", d.instance.tag
+    assert_equal "#{TMP_DIR}/socket.sock", d.instance.path
+    assert_equal true, d.instance.format_json
   end
 
   def test_receive_json
@@ -100,7 +108,7 @@ class UnixClientInputTest < Test::Unit::TestCase
   end
 
   def test_receive_json_list
-    d = create_driver(config_with_json_parser)
+    d = create_driver(config_with_json_parser_and_format_json)
     path = d.instance.path
     delimiter = "\n"
 
@@ -135,7 +143,7 @@ class UnixClientInputTest < Test::Unit::TestCase
   end
 
   def test_receive_json_list_with_one_delimiter
-    d = create_driver(config_with_json_parser)
+    d = create_driver(config_with_json_parser_and_format_json)
     path = d.instance.path
     delimiter = "\n"
 
@@ -178,6 +186,15 @@ class UnixClientInputTest < Test::Unit::TestCase
     BASE_CONFIG + %[
       delimiter \"#{delimiter}\"
     ] + %!
+      <parse>
+        @type json
+      </parse>
+    !
+  end
+
+  def config_with_json_parser_and_format_json
+    BASE_CONFIG + %!
+      format_json true
       <parse>
         @type json
       </parse>


### PR DESCRIPTION
Related: https://github.com/fluent/fluentd/issues/3356

Make it possible to receive the following types of JSON data.

```
[{"A":"x","B":"y"},\n
{"A":"x","B":"y"},\n
...]\n
```

```
[{"A":"x","B":"y"},{"A":"x","B":"y"},...]\n
```

To do so, make the following changes.

- When the parser type is `json`,  remove the extra characters such as `[`, `]`, `,`. 
- If the type of the parsed data is `Array`, use `emit_stream`.
